### PR TITLE
Allow settings to passed programmatically.

### DIFF
--- a/src/main/java/net/sf/cb2java/Settings.java
+++ b/src/main/java/net/sf/cb2java/Settings.java
@@ -23,33 +23,20 @@ import java.io.InputStream;
 import java.util.Properties;
 import net.sf.cb2java.types.SignPosition;
 
-public interface Settings {
-	static Settings DEFAULT = new Default();
+public class Settings {
 
-	String getEncoding();
+	String encoding = System.getProperty("file.encoding");
+	boolean littleEndian = false;
+	String floatConversion = "net.sf.cb2java.copybook.floating.IEEE754";
+	SignPosition signPosition = SignPosition.TRAILING;
+	int columnStart = 6;
+	int columnEnd = 72;
+	Values values = new Values();
 
-	Values getValues();
-
-	boolean getLittleEndian();
-
-	String getFloatConversion();
-
-	SignPosition getSignPosition();
-
-	int getColumnStart();
-
-	int getColumnEnd();
-
-	static class Default implements Settings {
-		private static final String DEFAULT_ENCODING;
-		private static final boolean DEFAULT_LITTLE_ENDIAN;
-		private static final String DEFAULT_FLOAT_CONVERSION;
-		private static final SignPosition DEFAULT_SIGN_POSITION;
-		private static final Values DEFAULT_VALUES = new Values();
-		private static final int DEFAULT_COLUMN_START;
-		private static final int DEFAULT_COLUMN_END;
-
-		static {
+	static Settings DEFAULT;
+	static public Settings DEFAULT() {
+		if(DEFAULT == null) {
+			DEFAULT = new Settings();
 			Properties props = new Properties();
 
 			try (InputStream is = Settings.class.getResourceAsStream("/copybook.props")) {
@@ -63,52 +50,80 @@ public interface Settings {
 				System.out.println("Could not load 'copybook.props' file, reverting to defaults.");
 			}
 
-			DEFAULT_ENCODING = getSetting("encoding", System.getProperty("file.encoding"), props);
-			DEFAULT_LITTLE_ENDIAN = "false".equals(getSetting("little-endian", "false", props));
-			DEFAULT_FLOAT_CONVERSION = getSetting("float-conversion", "net.sf.cb2java.copybook.floating.IEEE754",
-					props);
-			DEFAULT_SIGN_POSITION = "leading".equalsIgnoreCase(getSetting("default-sign-position", "trailing", props))
-					? SignPosition.LEADING : SignPosition.TRAILING;
-			DEFAULT_COLUMN_START = Integer.parseInt(getSetting("column.start", "6", props));
-			DEFAULT_COLUMN_END = Integer.parseInt(getSetting("column.end", "72", props));
+			DEFAULT.setEncoding(getSetting("encoding", DEFAULT.getEncoding(), props));
+			DEFAULT.setLittleEndian("false".equals(getSetting("little-endian", DEFAULT.isLittleEndian() + "", props)));
+			DEFAULT.setFloatConversion(getSetting("float-conversion", DEFAULT.getFloatConversion(), props));
+			DEFAULT.setSignPosition("leading".equalsIgnoreCase(getSetting("default-sign-position", "trailing", props))
+					? SignPosition.LEADING : SignPosition.TRAILING);
+			DEFAULT.setColumnStart(Integer.parseInt(getSetting("column.start", DEFAULT.getColumnStart() + "", props)));
+			DEFAULT.setColumnEnd(Integer.parseInt(getSetting("column.end", DEFAULT.getColumnEnd() + "", props)));
 		}
+		return DEFAULT;
+	}
 
-		private static String getSetting(String name, String defaultValue, Properties props) {
-			String result = defaultValue;
-			try {
-				result = System.getProperty("cb2java." + name, result);
-				result = props.getProperty(name, result);
-			} catch (RuntimeException e) {
-			}
-			return result;
-		}
+	public String getEncoding() {
+		return encoding;
+	}
 
-		public String getEncoding() {
-			return DEFAULT_ENCODING;
-		}
+	public void setEncoding(String encoding) {
+		this.encoding = encoding;
+	}
 
-		public String getFloatConversion() {
-			return DEFAULT_FLOAT_CONVERSION;
-		}
+	public boolean isLittleEndian() {
+		return littleEndian;
+	}
 
-		public boolean getLittleEndian() {
-			return DEFAULT_LITTLE_ENDIAN;
-		}
+	public void setLittleEndian(boolean littleEndian) {
+		this.littleEndian = littleEndian;
+	}
 
-		public Values getValues() {
-			return DEFAULT_VALUES;
-		}
+	public String getFloatConversion() {
+		return floatConversion;
+	}
 
-		public SignPosition getSignPosition() {
-			return DEFAULT_SIGN_POSITION;
-		}
+	public void setFloatConversion(String floatConversion) {
+		this.floatConversion = floatConversion;
+	}
 
-		public int getColumnStart() {
-			return DEFAULT_COLUMN_START;
-		}
+	public SignPosition getSignPosition() {
+		return signPosition;
+	}
 
-		public int getColumnEnd() {
-			return DEFAULT_COLUMN_END;
+	public void setSignPosition(SignPosition signPosition) {
+		this.signPosition = signPosition;
+	}
+
+	public int getColumnStart() {
+		return columnStart;
+	}
+
+	public void setColumnStart(int columnStart) {
+		this.columnStart = columnStart;
+	}
+
+	public int getColumnEnd() {
+		return columnEnd;
+	}
+
+	public void setColumnEnd(int columnEnd) {
+		this.columnEnd = columnEnd;
+	}
+
+	public Values getValues() {
+		return values;
+	}
+
+	public void setValues(Values values) {
+		this.values = values;
+	}
+
+	static private String getSetting(String name, String defaultValue, Properties props) {
+		String result = defaultValue;
+		try {
+			result = System.getProperty("cb2java." + name, result);
+			result = props.getProperty(name, result);
+		} catch (RuntimeException e) {
 		}
+		return result;
 	}
 }

--- a/src/main/java/net/sf/cb2java/copybook/CobolPreprocessor.java
+++ b/src/main/java/net/sf/cb2java/copybook/CobolPreprocessor.java
@@ -38,10 +38,10 @@ public class CobolPreprocessor {
 	private CobolPreprocessor() {
 	}
 
-	public static String preProcess(Reader reader) {
+	public static String preProcess(Reader reader, Settings settings) {
     	// TODO: figure out a way to pass copybook specific settings for non-default margins treated as comment.
-		int columnStart = Settings.DEFAULT.getColumnStart();
-		int columnEnd = Settings.DEFAULT.getColumnEnd();
+		int columnStart = settings.getColumnStart();
+		int columnEnd = settings.getColumnEnd();
 
 		StringBuffer sb = new StringBuffer();
 

--- a/src/main/java/net/sf/cb2java/copybook/Copybook.java
+++ b/src/main/java/net/sf/cb2java/copybook/Copybook.java
@@ -40,13 +40,8 @@ import net.sf.cb2java.types.SignPosition;
  * 
  * @author James Watson
  */
-public class Copybook extends Group implements Settings
+public class Copybook extends Group //implements Settings
 {
-    private String encoding = Settings.DEFAULT.getEncoding();
-    private boolean littleEndian = Settings.DEFAULT.getLittleEndian();
-    private String floatConversion = Settings.DEFAULT.getFloatConversion();
-    private SignPosition signPosition = Settings.DEFAULT.getSignPosition();
-    
     private Map<String, Element> redefines = new HashMap<String, Element>();
     
     private final Values values;
@@ -56,12 +51,13 @@ public class Copybook extends Group implements Settings
      *
      * @param name the name of the copybook
      */
-    Copybook(String name, Values values)
+    Copybook(String name, Values values, Settings settings)
     {
         super(name, 0, 0);
         
         this.values = values;
-        this.values.setEncoding(encoding);
+        this.setSettings(settings);
+        this.values.setEncoding(settings.getEncoding());
     }
     
     public Values getValues()
@@ -126,67 +122,6 @@ public class Copybook extends Group implements Settings
         
         return list;
     }
-    
-    /**
-     * Sets the encoding for the copybook instance, used for parsing
-     * and writing of data
-     * 
-     * @param encoding the encoding for the system
-     */
-    public void setEncoding(String encoding)
-    {
-        this.encoding = encoding;
-    }
-    
-    /**
-     * retrieves the current encoding for text
-     * 
-     * @return the encoding for text
-     */
-    public String getEncoding()
-    {
-        return encoding;
-    }
-    
-    public void setLittleEndian(boolean littleEndian)
-    {
-        this.littleEndian = littleEndian;
-    }
-    
-    public boolean getLittleEndian()
-    {
-        return littleEndian;
-    }
-    
-    public void setFloatConversion(String className)
-    {
-        this.floatConversion = className;
-    }
-    
-    public String getFloatConversion()
-    {
-        return floatConversion;
-    }
-    
-    public void setSignPosition(SignPosition position)
-    {
-        this.signPosition = position;
-    }
-    
-    public SignPosition getSignPosition()
-    {
-        return signPosition;
-    }
-    
-	@Override
-	public int getColumnStart() {
-		return Settings.DEFAULT.getColumnStart();
-	}
-
-	@Override
-	public int getColumnEnd() {
-		return Settings.DEFAULT.getColumnEnd();
-	}
 
 	/**
      * a helper class for buffering the data as it is processed

--- a/src/main/java/net/sf/cb2java/copybook/CopybookAnalyzer.java
+++ b/src/main/java/net/sf/cb2java/copybook/CopybookAnalyzer.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import net.sf.cb2java.Settings;
 import net.sf.cb2java.Values;
 import net.sf.cb2java.types.Element;
 import net.sf.cb2java.types.Group;
@@ -84,6 +85,7 @@ class CopybookAnalyzer extends DepthFirstAdapter
     private Parser parser;
     private Item document;
     private Item current;
+    private Settings settings;
     
     /**
      * Creates a new instance with the given parser and
@@ -92,12 +94,13 @@ class CopybookAnalyzer extends DepthFirstAdapter
      * @param copyBookName the name to give this copybook
      * @param parser sablecc parser instance 
      */
-	CopybookAnalyzer(String copyBookName, Parser parser)
+	CopybookAnalyzer(String copyBookName, Parser parser, Settings settings)
     {
-        document = new Item(values, true);
+        document = new Item(values, true, settings);
         document.name = copyBookName;
         current = document;
 		this.parser = parser;
+		this.settings = settings;
 	}
 	
 	/**
@@ -127,7 +130,7 @@ class CopybookAnalyzer extends DepthFirstAdapter
 
     private void walkTree(Item item)
     {
-        item.getElement().setSettings((Copybook) document.getElement());
+        item.getElement().setSettings(document.getElement().getSettings());
         
         for (Iterator<?> i = item.children.iterator(); i.hasNext();) {
             Item child = (Item) i.next();
@@ -176,7 +179,7 @@ class CopybookAnalyzer extends DepthFirstAdapter
 	public void inAItem(AItem node)
     {
         Item prevItem = current;
-        current = new Item(values, false);
+        current = new Item(values, false, settings);
         current.level = Integer.parseInt(node.getNumberNot88().toString().trim());
         current.name = node.getDataNameOrFiller().toString().trim();
         
@@ -265,12 +268,12 @@ class CopybookAnalyzer extends DepthFirstAdapter
 
 	public void inALeadingLeadingOrTrailing(ALeadingLeadingOrTrailing node)
     {
-        current.signPosition = SignPosition.LEADING;
+        current.getSettings().setSignPosition(SignPosition.LEADING);
     }
 
     public void inATrailimngLeadingOrTrailing(ALeadingLeadingOrTrailing node)
     {
-        current.signPosition = SignPosition.TRAILING;
+        current.getSettings().setSignPosition(SignPosition.TRAILING);
     }
 
 	//======================= USAGE CLAUSE ==========================

--- a/src/main/java/net/sf/cb2java/copybook/CopybookParser.java
+++ b/src/main/java/net/sf/cb2java/copybook/CopybookParser.java
@@ -25,6 +25,7 @@ import java.io.PushbackReader;
 import java.io.Reader;
 import java.io.StringReader;
 
+import net.sf.cb2java.Settings;
 import net.sf.cb2xml.sablecc.lexer.Lexer;
 import net.sf.cb2xml.sablecc.lexer.LexerException;
 import net.sf.cb2xml.sablecc.node.Start;
@@ -58,7 +59,12 @@ public class CopybookParser
     {        
         return parse(name, new InputStreamReader(stream));
     }
-    
+
+    public static Copybook parse(Settings settings, String name, InputStream stream)
+    {
+        return parse(settings, name, new InputStreamReader(stream));
+    }
+
     /**
      * Parses a copybook definition and returns a Copybook instance
      * 
@@ -67,16 +73,16 @@ public class CopybookParser
      * 
      * @return a copybook instance containing the parse tree for the definition
      */
-    public static Copybook parse(String name, Reader reader)
+    public static Copybook parse(Settings settings, String name, Reader reader)
     {        
-        String preProcessed = CobolPreprocessor.preProcess(reader);
+        String preProcessed = CobolPreprocessor.preProcess(reader, settings);
         StringReader sr = new StringReader(preProcessed);
         PushbackReader pbr = new PushbackReader(sr, 1000);
         
         Lexer lexer = debug ? new DebugLexer(pbr) : new Lexer(pbr);
         
         Parser parser = new Parser(lexer);
-        CopybookAnalyzer copyBookAnalyzer = new CopybookAnalyzer(name, parser);
+        CopybookAnalyzer copyBookAnalyzer = new CopybookAnalyzer(name, parser, settings);
         Start ast;
         try {
 			ast = parser.parse();
@@ -91,4 +97,10 @@ public class CopybookParser
         
         return copyBookAnalyzer.getDocument();
     }
+
+    public static Copybook parse(String name, Reader reader) {
+
+        return parse(Settings.DEFAULT(), name, reader);
+    }
+
 }

--- a/src/main/java/net/sf/cb2java/copybook/Item.java
+++ b/src/main/java/net/sf/cb2java/copybook/Item.java
@@ -20,6 +20,8 @@ package net.sf.cb2java.copybook;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
 import net.sf.cb2java.Settings;
 import net.sf.cb2java.Value;
 import net.sf.cb2java.Values;
@@ -42,14 +44,22 @@ class Item
     final boolean document;
     
     final Values values;
+
+    public Settings getSettings() {
+        return settings;
+    }
+
+    final Settings settings;
     
     /**
      * @param analyzer
      */
-    Item(final Values values, final boolean document)
+    Item(final Values values, final boolean document, Settings settings)
     {
         this.values = values;
         this.document = document;
+        this.settings = settings;
+        signPosition = settings.getSignPosition();
     }
 
     String name;
@@ -66,7 +76,7 @@ class Item
     
     boolean isAlpha;
     boolean signSeparate;
-    SignPosition signPosition = Settings.DEFAULT.getSignPosition();
+    SignPosition signPosition;
     
     String picture;
     Value value;
@@ -128,7 +138,7 @@ class Item
     
     private void createDocument()
     {
-        element = new Copybook(name, values);
+        element = new Copybook(name, values, settings);
     }
     
     private void createGroup()

--- a/src/main/java/net/sf/cb2java/types/Binary.java
+++ b/src/main/java/net/sf/cb2java/types/Binary.java
@@ -122,12 +122,12 @@ public class Binary extends Numeric {
         @Override
         public byte[] toBytes(Object data) {
             byte[] bytes = super.toBytes(data);
-            return getSettings().getLittleEndian() ? reverse(bytes) : bytes;
+            return getSettings().isLittleEndian() ? reverse(bytes) : bytes;
         }
         
         @Override
         public Data parse(byte[] input) {
-            return super.parse(getSettings().getLittleEndian() ? reverse(input) : input);
+            return super.parse(getSettings().isLittleEndian() ? reverse(input) : input);
         }
     }
 }

--- a/src/main/java/net/sf/cb2java/types/Element.java
+++ b/src/main/java/net/sf/cb2java/types/Element.java
@@ -42,7 +42,7 @@ public abstract class Element {
     /** the absolute position of the where this item starts in data */
     private int position;
     /** the instance that represents the data that defines this element */
-    private Settings settings = Settings.DEFAULT;
+    private Settings settings;
     /** the default value of this element */
     private Value value;
     /** the parent of this element */
@@ -219,7 +219,7 @@ public abstract class Element {
      * 
      * @return the parent of this element
      */
-    private Group getParent(){
+    public Group getParent(){
         return parent;
     }
     
@@ -237,13 +237,13 @@ public abstract class Element {
      * 
      * @return the settings for this element
      */
-    protected Settings getSettings() {
+    public Settings getSettings() {
         if (settings != null) {
             return settings;
         } else if (getParent() != null) {
             return getParent().getSettings();
         } else {
-            return null;
+            return Settings.DEFAULT();
         }
     }
     


### PR DESCRIPTION
The use case is to not necessarily rely on the properties file, as within one process run, different copybooks may require different settings.
By default, the behavior is the same as before.